### PR TITLE
Add simple pagination for blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Planned improvements and current/future features:
     - [ ] Layout options
 - [ ] 📄 Add recommended similar blog posts items to the bottom of each blog post
 - [ ] 📄 Add blog post categories pages
-- [ ] 📄 Add pagination to blog posts
+- [X] 📄 Add pagination to blog posts
 
 ---
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -125,9 +125,8 @@ export default function BlogPage() {
                     <motion.div
                         key="no-results"
                         className="flex flex-col items-center text-center text-gray-600 dark:text-gray-300 mt-12 px-4"
-                        initial={{opacity: 0, y: 10}}
-                        animate={{opacity: 1, y: 0}}
-                        exit={{opacity: 0, y: 10}}
+                        initial={{opacity: 0}}
+                        animate={{opacity: 1}}
                         transition={{duration: 0.3, ease: 'easeOut'}}
                     >
                         <FaFrown className="text-4xl md:text-5xl mb-3 text-gray-400 dark:text-gray-500"/>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {useState, useMemo} from 'react';
+import {useState, useMemo, useEffect} from 'react';
 import {FaFrown} from 'react-icons/fa';
 import {motion, AnimatePresence} from 'framer-motion';
 import FilterDropdown from '@/components/FilterDropdown';
@@ -16,6 +16,8 @@ export default function BlogPage() {
     const [selectedTags, setSelectedTags] = useState<string[]>([]);
     const [tagDrafts, setTagDrafts] = useState<string[]>([]);
     const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+    const [currentPage, setCurrentPage] = useState(1);
+    const POSTS_PER_PAGE = 5;
 
     // Determines the set of unique blog post tags and their count
     const uniqueTags = useMemo(() => {
@@ -48,6 +50,11 @@ export default function BlogPage() {
         setTagDrafts([]);
     };
 
+    // Reset to the first page when filters or sort order change
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [selectedTags, sortOrder]);
+
     // Filter and sort the posts based on selected tags and sort order
     const filteredPosts = useMemo(() => {
         return posts
@@ -61,6 +68,13 @@ export default function BlogPage() {
                 return sortOrder === 'asc' ? dateA - dateB : dateB - dateA;
             });
     }, [selectedTags, sortOrder]);
+
+    // Calculate total pages and paginate the posts
+    const totalPages = Math.ceil(filteredPosts.length / POSTS_PER_PAGE);
+    const paginatedPosts = useMemo(() => {
+        const start = (currentPage - 1) * POSTS_PER_PAGE;
+        return filteredPosts.slice(start, start + POSTS_PER_PAGE);
+    }, [filteredPosts, currentPage]);
 
     return (
         <section className="px-4 max-w-4xl mx-auto">
@@ -103,7 +117,7 @@ export default function BlogPage() {
                         exit={{opacity: 0}}
                         transition={{duration: 0.2}}
                     >
-                        {filteredPosts.map(post => (
+                        {paginatedPosts.map(post => (
                             <BlogPost key={post.slug} {...post} />
                         ))}
                     </motion.div>
@@ -127,6 +141,89 @@ export default function BlogPage() {
                     </motion.div>
                 )}
             </AnimatePresence>
+
+            {/* Pagination Controls */}
+            {totalPages > 1 && (
+                <div className="flex justify-center items-center gap-2 mt-8">
+                    {/* Prev Button */}
+                    <button
+                        className={`px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 transition-transform duration-150 ${currentPage === 1 ? 'cursor-default opacity-60' : 'cursor-pointer hover:bg-gray-300 dark:hover:bg-gray-600'}`}
+                        onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+                        disabled={currentPage === 1}
+                    >
+                        Prev
+                    </button>
+
+                    {/* First page */}
+                    <button
+                        className={`px-3 py-1 rounded transition-colors duration-150 ${currentPage === 1 ? 'bg-blue-500 text-white cursor-default' : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700'}`}
+                        onClick={() => setCurrentPage(1)}
+                        disabled={currentPage === 1}
+                    >
+                        1
+                    </button>
+
+                    {/* Left Ellipsis */}
+                    {currentPage > 3 && (
+                        <span className="px-2 select-none">...</span>
+                    )}
+
+                    {/* Previous page number (if not 1 and not already shown) */}
+                    {currentPage > 2 && (
+                        <button
+                            className={`px-3 py-1 rounded transition-colors duration-150 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700`}
+                            onClick={() => setCurrentPage(currentPage - 1)}
+                        >
+                            {currentPage - 1}
+                        </button>
+                    )}
+
+                    {/* Current page (not 1 or last) */}
+                    {currentPage !== 1 && currentPage !== totalPages && (
+                        <button
+                            className={`px-3 py-1 rounded bg-blue-500 text-white transition-colors duration-150 cursor-default`}
+                            disabled
+                        >
+                            {currentPage}
+                        </button>
+                    )}
+
+                    {/* Next page number (if not last and not already shown) */}
+                    {currentPage < totalPages - 1 && (
+                        <button
+                            className={`px-3 py-1 rounded transition-colors duration-150 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700`}
+                            onClick={() => setCurrentPage(currentPage + 1)}
+                        >
+                            {currentPage + 1}
+                        </button>
+                    )}
+
+                    {/* Right Ellipsis */}
+                    {currentPage < totalPages - 2 && (
+                        <span className="px-2 select-none">...</span>
+                    )}
+
+                    {/* Last page */}
+                    {totalPages > 1 && (
+                        <button
+                            className={`px-3 py-1 rounded transition-colors duration-150 ${currentPage === totalPages ? 'bg-blue-500 text-white cursor-default' : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700'}`}
+                            onClick={() => setCurrentPage(totalPages)}
+                            disabled={currentPage === totalPages}
+                        >
+                            {totalPages}
+                        </button>
+                    )}
+
+                    {/* Next Button */}
+                    <button
+                        className={`px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 transition-transform duration-150 ${currentPage === totalPages ? 'cursor-default opacity-60' : 'cursor-pointer hover:bg-gray-300 dark:hover:bg-gray-600'}`}
+                        onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+                        disabled={currentPage === totalPages}
+                    >
+                        Next
+                    </button>
+                </div>
+            )}
         </section>
     );
 }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -17,6 +17,7 @@ export default function BlogPage() {
     const [tagDrafts, setTagDrafts] = useState<string[]>([]);
     const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
 
+    // Determines the set of unique blog post tags and their count
     const uniqueTags = useMemo(() => {
         const tagCounts: Record<string, number> = {};
         posts.forEach(post => {
@@ -29,21 +30,25 @@ export default function BlogPage() {
             .sort((a, b) => a.tag.localeCompare(b.tag));
     }, []);
 
+    // Function to toggle a tag in the draft state
     const toggleTagDraft = (tag: string) => {
         setTagDrafts(prev =>
             prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]
         );
     };
 
+    // Function to apply the selected tags as filters
     const applyFilters = () => {
         setSelectedTags([...tagDrafts]);
     };
 
+    // Function to clear all selected filters
     const clearFilters = () => {
         setSelectedTags([]);
         setTagDrafts([]);
     };
 
+    // Filter and sort the posts based on selected tags and sort order
     const filteredPosts = useMemo(() => {
         return posts
             .filter(post =>

--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -19,11 +19,10 @@ export default function BlogPost({slug, title, summary, date, tags}: BlogPostPro
     return (
         <Link href={`/blog/${slug}`}>
             <motion.div
-                initial={{opacity: 0, y: 30}}
-                animate={{opacity: 1, y: 0}}
+                initial={{opacity: 0}}
+                animate={{opacity: 1}}
                 transition={{
                     opacity: {duration: 0.8},
-                    y: {type: "spring", stiffness: 100, damping: 25}
                 }}
                 whileHover={{
                     scale: 1.05,

--- a/src/components/ProjectTile.tsx
+++ b/src/components/ProjectTile.tsx
@@ -23,12 +23,9 @@ export default function ProjectTile({slug, title, image, description}: ProjectTi
     return (
         <Link href={`/projects/${slug}`} className="block group">
             <motion.div
-                initial={{opacity: 0, y: 30}}
-                animate={{opacity: 1, y: 0}}
-                transition={{
-                    opacity: {duration: 0.8},
-                    y: {type: "spring", stiffness: 100, damping: 25}
-                }}
+                initial={{opacity: 0}}
+                animate={{opacity: 1}}
+                transition={{opacity: {duration: 0.8}}}
                 whileHover={{
                     scale: 1.05,
                     filter: 'brightness(1.15)',

--- a/src/components/WorkItem.tsx
+++ b/src/components/WorkItem.tsx
@@ -22,12 +22,9 @@ export default function WorkItem({slug, company, title, start, end, description,
     return (
         <Link href={`/work/${slug}`} className="block group">
             <motion.div
-                initial={{opacity: 0, y: 30}}
-                animate={{opacity: 1, y: 0}}
-                transition={{
-                    opacity: {duration: 0.8},
-                    y: {type: "spring", stiffness: 100, damping: 25}
-                }}
+                initial={{opacity: 0}}
+                animate={{opacity: 1}}
+                transition={{opacity: {duration: 0.8}}}
                 whileHover={{
                     scale: 1.05,
                     transition: {

--- a/src/data/blog.ts
+++ b/src/data/blog.ts
@@ -68,6 +68,34 @@ const posts = [
         summary: 'Take a deep dive into the architecture and components of the Java Virtual Machine.',
         date: '2022-02-20',
         tags: ['java', 'jvm', 'internals', 'performance']
+    },
+    {
+        slug: 'post11',
+        title: 'System Design Fundamentals',
+        summary: 'Explore the core principles and patterns of system design for scalable, reliable applications.',
+        date: '2022-03-01',
+        tags: ['system design', 'architecture', 'scalability', 'reliability']
+    },
+    {
+        slug: 'post12',
+        title: 'Load Balancers: Deep Dive',
+        summary: 'Understand load balancers, their types, drawbacks, implementation, and how they differ from reverse proxies.',
+        date: '2022-03-10',
+        tags: ['load balancer', 'reverse proxy', 'networking', 'system design']
+    },
+    {
+        slug: 'post13',
+        title: 'SQL vs NoSQL: Trade-offs and Applications',
+        summary: 'Explore the differences, trade-offs, and use cases for SQL and NoSQL databases.',
+        date: '2022-03-20',
+        tags: ['sql', 'nosql', 'databases', 'system design']
+    },
+    {
+        slug: 'post14',
+        title: 'Caching in System Design: Redis, Memcached, and More',
+        summary: 'Learn about caching strategies, tools like Redis and Memcached, and their role in scalable system design.',
+        date: '2022-03-30',
+        tags: ['caching', 'redis', 'memcached', 'performance', 'system design']
     }
 ]
 

--- a/src/data/blog/post11.mdx
+++ b/src/data/blog/post11.mdx
@@ -1,0 +1,128 @@
+---
+title: "System Design Fundamentals"
+summary: "Explore the core principles and patterns of system design for scalable, reliable applications."
+date: "2022-03-01"
+tags:
+  - System Design
+  - Architecture
+  - Scalability
+  - Reliability
+---
+
+# System Design Fundamentals
+
+System design is the process of defining the architecture, components, modules, interfaces, and data for a system to satisfy specified requirements. It is a critical skill for software engineers, especially when building scalable, reliable, and maintainable systems.
+
+## Why System Design Matters
+
+- **Scalability**: Ensures your system can handle an increased load.
+- **Reliability**: Guarantees your system works as expected, even in the face of failures.
+- **Maintainability**: Makes it easier to add features and fix bugs.
+- **Performance**: Delivers fast and responsive user experiences.
+- **Cost Efficiency**: Optimizes resource usage and infrastructure costs.
+
+## Key Principles
+
+### 1. Scalability
+- **Vertical Scaling**: Adding more power (CPU, RAM) to a single machine.
+- **Horizontal Scaling**: Adding more machines to distribute the load.
+- **Elasticity**: Ability to automatically scale up/down based on demand.
+
+### 2. Reliability & Availability
+- **Redundancy**: Duplicate components to avoid single points of failure.
+- **Failover**: Automatic switching to a standby system in case of failure.
+- **Replication**: Copying data across multiple nodes for durability.
+- **Monitoring & Alerting**: Detect and respond to issues quickly.
+
+### 3. Maintainability
+- **Modularity**: Break system into independent, replaceable modules.
+- **Documentation**: Keep architecture and APIs well documented.
+- **Testing**: Automated tests for components and integration.
+
+### 4. Performance
+- **Caching**: Store frequently accessed data in memory.
+- **Load Balancing**: Distribute requests evenly across servers.
+- **Asynchronous Processing**: Use queues and background jobs for heavy tasks.
+
+## Common Architectural Patterns
+
+- **Monolithic Architecture**: Single codebase, easy to develop but hard to scale.
+- **Microservices**: Independent services, easier to scale and maintain, but more complex.
+- **Event-Driven Architecture**: Components communicate via events, enabling loose coupling.
+- **Layered Architecture**: Presentation, business logic, and data layers.
+- **Service-Oriented Architecture (SOA)**: Services communicate over a network, often using standardized protocols.
+
+## System Design Process
+
+1. **Requirement Gathering**
+- Functional: What should the system do?
+- Non-functional: Performance, reliability, scalability, security, etc.
+2. **High-Level Architecture**
+- Identify major components and their interactions.
+- Draw diagrams (e.g., block diagrams, sequence diagrams).
+3. **Component Design**
+- Define APIs, data contracts, and responsibilities.
+- Consider failure modes and recovery.
+4. **Data Modeling**
+- Choose between SQL/NoSQL, normalization, indexing, partitioning.
+5. **Scalability & Reliability Planning**
+- Plan for load balancing, replication, sharding, and failover.
+6. **Trade-off Analysis**
+- Evaluate the pros and cons of different approaches.
+
+## Example: Designing a URL Shortener
+
+### Requirements
+- Shorten long URLs
+- Redirect to original URL
+- Track analytics (clicks, referrers)
+- High availability and low latency
+
+### High-Level Components
+- **API Server**: Handles requests to shorten and redirect URLs.
+- **Database**: Stores mappings from short codes to original URLs.
+- **Cache**: Speeds up redirection by caching popular URLs.
+- **Analytics Processor**: Collects and aggregates usage data.
+- **Load Balancer**: Distributes incoming requests.
+
+### Scalability Considerations
+- **Sharding**: Split database by hash of short code.
+- **Replication**: Use master-slave or multi-master replication.
+- **Caching**: Use Redis/Memcached for hot URLs.
+- **CDN**: Cache static assets and redirect logic at the edge.
+
+### Reliability Considerations
+- **Failover**: Use multiple API servers and databases.
+- **Backups**: Regularly backup database.
+- **Monitoring**: Track errors, latency, and traffic spikes.
+
+### Security Considerations
+- **Rate Limiting**: Prevent abuse of the API.
+- **Validation**: Ensure URLs are valid and safe.
+- **Authentication**: For analytics and admin endpoints.
+
+## Trade-offs in System Design
+
+- **Consistency vs. Availability**: CAP theorem—choose what to sacrifice during network partitions.
+- **Latency vs. Throughput**: Optimize for one may impact the other.
+- **Simplicity vs. Flexibility**: More features can mean more complexity.
+
+## Interview Tips
+
+- Always clarify requirements and constraints.
+- Draw diagrams to communicate your ideas.
+- Discuss trade-offs and justify your choices.
+- Think about monitoring, scaling, and failure scenarios.
+- Practice with common system design questions (e.g., design Twitter, Instagram, a chat app).
+
+## Further Reading
+
+- [Designing Data-Intensive Applications by Martin Kleppmann](https://dataintensive.net/)
+- [System Design Primer (GitHub)](https://github.com/donnemartin/system-design-primer)
+- [Google SRE Book](https://sre.google/books/)
+
+## Conclusion
+
+System design is about making informed trade-offs to meet business and technical goals. Mastering it requires practice, curiosity, and a willingness to learn from real-world systems.
+
+> 💡 **Remember**: There is no one-size-fits-all solution in system design. Every system is unique, and the best design is the one that meets your specific needs.

--- a/src/data/blog/post12.mdx
+++ b/src/data/blog/post12.mdx
@@ -1,0 +1,109 @@
+---
+title: "Load Balancers: Deep Dive"
+summary: "Understand load balancers, their types, drawbacks, implementation, and how they differ from reverse proxies."
+date: "2022-03-10"
+tags:
+  - Load Balancer
+  - Reverse Proxy
+  - Networking
+  - System Design
+---
+
+# Load Balancers: Deep Dive
+
+A **load balancer** is a critical component in modern distributed systems, responsible for distributing incoming network traffic across multiple servers to ensure reliability, performance, and scalability.
+
+## Why Use a Load Balancer?
+
+- **High Availability**: Prevents a single server from becoming a point of failure.
+- **Scalability**: Allows you to add or remove servers as demand changes.
+- **Performance**: Distributes requests to avoid overloading any single server.
+- **Security**: Can hide internal server details and provide SSL termination.
+
+## Types of Load Balancers
+
+### 1. Layer 4 (Transport Layer)
+- Operates at the TCP/UDP level.
+- Routes traffic based on IP address and port.
+- Examples: AWS Network Load Balancer, HAProxy (TCP mode).
+
+### 2. Layer 7 (Application Layer)
+- Operates at the HTTP/HTTPS level.
+- Can make routing decisions based on URL, headers, cookies, etc.
+- Examples: NGINX, AWS Application Load Balancer, Traefik.
+
+## Load Balancing Algorithms
+
+- **Round Robin**: Distributes requests sequentially across servers.
+- **Least Connections**: Sends traffic to the server with the fewest active connections.
+- **IP Hash**: Routes requests based on client IP, useful for session persistence.
+- **Weighted Round Robin**: Assigns more traffic to more powerful servers.
+
+## Health Checks
+
+Load balancers regularly check the health of backend servers. If a server fails, it is temporarily removed from the pool until it recovers.
+
+## Drawbacks and Challenges
+
+- **Single Point of Failure**: If the load balancer itself fails, the whole system can go down. Use multiple load balancers and DNS failover for redundancy.
+- **Complexity**: Adds configuration and operational overhead.
+- **Latency**: Introduces an extra network hop, which can add slight delays.
+- **Cost**: Managed load balancers (cloud) can be expensive at scale.
+
+## Implementation Example: NGINX as a Load Balancer
+
+```nginx
+http {
+  upstream backend {
+    server backend1.example.com;
+    server backend2.example.com;
+  }
+  server {
+    listen 80;
+    location / {
+      proxy_pass http://backend;
+    }
+  }
+}
+```
+
+## Load Balancer vs Reverse Proxy
+
+- **Load Balancer**: Distributes traffic across multiple backend servers, often for scaling and redundancy.
+- **Reverse Proxy**: Forwards client requests to one or more backend servers, often for caching, SSL termination, or security. Can also act as a load balancer.
+- **Overlap**: Many tools (e.g., NGINX, HAProxy) can serve as both.
+
+### Key Differences
+- **Purpose**: Load balancer focuses on distribution; reverse proxy focuses on abstraction and security.
+- **Session Persistence**: Load balancers may need sticky sessions; reverse proxies often do not.
+
+## Advanced Topics
+
+### Global Load Balancing
+- Use DNS-based or Anycast routing to distribute traffic across regions or data centers.
+
+### SSL Termination
+- Offload SSL decryption at the load balancer to reduce backend server load.
+
+### Autoscaling
+- Integrate with orchestration tools (Kubernetes, AWS ASG) to automatically add/remove backend servers.
+
+## Best Practices
+
+- Always deploy at least two load balancers for redundancy.
+- Monitor health and performance metrics.
+- Use configuration management for reproducible setups.
+- Regularly test failover and recovery scenarios.
+
+## Real-World Example: E-commerce Platform
+
+- **User Traffic**: Hits DNS, routed to the nearest load balancer.
+- **Load Balancer**: Distributes requests to web servers.
+- **Web Servers**: Communicate with application and database layers.
+- **Failover**: If a web server or load balancer fails, traffic is rerouted automatically.
+
+## Conclusion
+
+Load balancers are essential for building robust, scalable, and high-performance systems. Understanding their types, algorithms, and best practices is key to designing resilient architectures.
+
+> 🧠 **Remember**: Always avoid single points of failure and plan for growth and failure from day one.

--- a/src/data/blog/post13.mdx
+++ b/src/data/blog/post13.mdx
@@ -1,0 +1,117 @@
+---
+title: "SQL vs NoSQL: Trade-offs and Applications"
+summary: "Explore the differences, trade-offs, and use cases for SQL and NoSQL databases."
+date: "2022-03-20"
+tags:
+  - SQL
+  - NoSQL
+  - Databases
+  - System Design
+---
+
+# SQL vs NoSQL: Trade-offs and Applications
+
+Choosing between **SQL** and **NoSQL** databases is a fundamental system design decision. The right choice can impact scalability, performance, and maintainability for years to come.
+
+## What is SQL?
+
+- **Relational**: Data is organized in tables with predefined schemas.
+- **ACID Compliance**: Guarantees Atomicity, Consistency, Isolation, Durability for transactions.
+- **Strong Consistency**: Data is always up to date and reliable.
+- **Examples**: MySQL, PostgreSQL, Oracle, Microsoft SQL Server.
+
+### SQL Strengths
+- Complex queries (JOINs, aggregations)
+- Data integrity and validation
+- Mature tooling and ecosystem
+- Transactional support
+
+### SQL Weaknesses
+- Harder to scale horizontally (sharding is complex)
+- Schema changes can be disruptive
+- Not ideal for unstructured or rapidly evolving data
+
+## What is NoSQL?
+
+- **Non-relational**: Flexible schemas can be documented, key-value, column-family, or graph-based.
+- **BASE Properties**: Basically Available, Soft state, Eventually consistent.
+- **Eventual Consistency**: Data may not be immediately consistent across all nodes.
+- **Examples**: MongoDB (document), Cassandra (column), DynamoDB (key-value), Neo4j (graph), Redis (key-value).
+
+### NoSQL Strengths
+- Horizontal scalability (easy to add nodes)
+- Flexible, dynamic schemas
+- High throughput for large-scale workloads
+- Suited for unstructured or semi-structured data
+
+### NoSQL Weaknesses
+- Limited support for complex queries and transactions
+- Weaker consistency guarantees (eventual consistency)
+- Less mature tooling for some databases
+
+## Trade-offs
+
+| Feature         | SQL                | NoSQL                |
+|-----------------|--------------------|----------------------|
+| Schema          | Fixed              | Flexible             |
+| Transactions    | Strong (ACID)      | Limited/None         |
+| Scalability     | Vertical           | Horizontal           |
+| Joins           | Supported          | Rare/Not supported   |
+| Consistency     | Strong             | Eventual             |
+| Query Language  | SQL                | Varies (JSON, CQL)   |
+| Use Cases       | OLTP, analytics    | Big data, real-time  |
+
+## When to Use SQL
+
+- Complex queries and reporting
+- Data integrity is critical (banking, finance)
+- Well-defined, stable schema
+- Need for strong consistency and transactions
+
+## When to Use NoSQL
+
+- Rapidly changing or unstructured data
+- Massive scale and high throughput (IoT, analytics, social feeds)
+- Flexible or evolving schema
+- Geographically distributed systems
+
+> 💡 **Tip**: Many modern systems use both (polyglot persistence) for different needs.
+
+## Deep Dive: Application Scenarios
+
+### E-commerce
+- **SQL**: Orders, payments, inventory (strong consistency, transactions)
+- **NoSQL**: Product catalog, user sessions, recommendations (flexible, scalable)
+
+### Analytics
+- **NoSQL**: Event logs, clickstreams, time-series data (high write throughput)
+- **SQL**: Aggregated reports, dashboards (complex queries)
+
+### Social Networks
+- **NoSQL**: User feeds, messages, relationships (graph or document DBs)
+- **SQL**: User profiles, authentication (structured, transactional)
+
+### IoT and Real-Time Apps
+- **NoSQL**: Sensor data, telemetry (high-volume, flexible schema)
+
+## Polyglot Persistence
+
+Many organizations use both SQL and NoSQL databases in the same system, choosing the best tool for each job. For example, using PostgreSQL for transactional data and MongoDB for user-generated content.
+
+## Migration and Integration
+
+- **Data Migration**: Moving from SQL to NoSQL (or vice versa) can be complex—plan for data mapping, consistency, and downtime.
+- **Integration**: Use APIs, ETL pipelines, or data lakes to combine data from multiple sources.
+
+## Best Practices
+
+- Always start with your application's requirements.
+- Consider future growth and data access patterns.
+- Benchmark different databases with real workloads.
+- Plan for backup, recovery, and monitoring.
+
+## Conclusion
+
+Understand your application's requirements before choosing a database technology. The right tool depends on your use case, not hype or trends.
+
+> 🧠 **Remember**: There is no perfect database—only the best fit for your needs. Evaluate trade-offs carefully and be ready to adapt as your system evolves.

--- a/src/data/blog/post14.mdx
+++ b/src/data/blog/post14.mdx
@@ -1,0 +1,96 @@
+---
+title: "Caching in System Design: Redis, Memcached, and More"
+summary: "Learn about caching strategies, tools like Redis and Memcached, and their role in scalable system design."
+date: "2022-03-30"
+tags:
+  - Caching
+  - Redis
+  - Memcached
+  - Performance
+  - System Design
+---
+
+# Caching in System Design: Redis, Memcached, and More
+
+Caching is a technique to store frequently accessed data in a fast storage layer to reduce latency and load on primary databases. Effective caching can dramatically improve system performance and scalability.
+
+## Why Cache?
+
+- **Reduce Latency**: Serve data faster by avoiding slow database or API calls.
+- **Decrease Load**: Offload backend databases and services.
+- **Improve Scalability**: Handle more requests efficiently with the same infrastructure.
+- **Enhance User Experience**: Faster response times lead to happier users.
+
+## Common Caching Strategies
+
+- **Read-Through**: Application reads from cache first; if not found, loads from database and populates cache.
+- **Write-Through**: Writes go to cache and database simultaneously, keeping them in sync.
+- **Write-Back (Write-Behind)**: Writes go to cache and are asynchronously written to the database.
+- **Cache Aside (Lazy Loading)**: Application manages cache population and invalidation explicitly.
+- **Time-to-Live (TTL)**: Cached data expires after a set period.
+
+## Tools: Redis vs Memcached
+
+| Feature      | Redis         | Memcached     |
+|--------------|--------------|--------------|
+| Data Types   | Strings, Lists, Sets, Hashes | Strings only |
+| Persistence  | Yes          | No           |
+| Replication  | Yes          | No           |
+| Pub/Sub      | Yes          | No           |
+| Use Cases    | Sessions, Queues, Leaderboards | Simple cache |
+| Scripting    | Lua scripts  | No           |
+
+### Redis
+- In-memory data structure store with persistence options.
+- Supports advanced data types and atomic operations.
+- Can be used for caching, pub/sub, queues, rate limiting, and more.
+
+### Memcached
+- Simple, high-performance, distributed memory object caching system.
+- Focused on speed and simplicity.
+- No persistence or advanced data types.
+
+## Example: Redis Caching in Python
+
+```python
+import redis
+r = redis.Redis(host='localhost', port=6379, db=0)
+r.set('key', 'value', ex=60)  # Set with 60s TTL
+print(r.get('key'))
+```
+
+## Drawbacks and Considerations
+
+- **Stale Data**: Cached data may become outdated if not invalidated properly.
+- **Cache Invalidation**: One of the hardest problems in computer science. Strategies include TTL, explicit invalidation, and event-driven updates.
+- **Memory Limits**: Caches are typically in-memory and limited by available RAM.
+- **Consistency**: Risk of serving outdated or inconsistent data.
+- **Cold Starts**: Cache misses can cause spikes in backend load.
+
+## Beyond Redis/Memcached
+
+- **CDNs (Content Delivery Networks)**: Cache static assets closer to users for faster delivery.
+- **Local Caching**: In-process memory for ultra-fast access (e.g., LRU caches in application code).
+- **Distributed Caching**: Share cache across multiple servers for consistency and scalability.
+- **Hybrid Approaches**: Combine local, distributed, and CDN caching for optimal performance.
+
+## Real-World Use Cases
+
+- **Web Applications**: Cache rendered HTML, API responses, or session data.
+- **E-commerce**: Cache product details, inventory, and pricing.
+- **Social Media**: Cache user profiles, timelines, and trending topics.
+- **Analytics**: Cache query results and dashboards.
+
+## Best Practices
+
+- Cache only what is expensive to compute or fetch.
+- Set appropriate TTLs to balance freshness and performance.
+- Monitor cache hit/miss rates and adjust strategies as needed.
+- Plan for cache failures—always have a fallback to the source of truth.
+- Secure your cache (authentication, network restrictions).
+
+## Conclusion
+
+Caching is vital for high-performance systems, but must be used judiciously to avoid consistency issues and stale data. A well-designed caching strategy can be the difference between a sluggish app and a lightning-fast user experience.
+
+> 💡 **Remember**: Always plan for cache invalidation and data consistency. Test your caching strategy under real-world conditions.


### PR DESCRIPTION
This PR adds:
* Simple pagination for blog posts whenever there are more than 5 (the number can be adjusted)
* Adds more sample blog posts
* Updates motion effects for `ProjectTile`, `WorkItem`, and `BlogPost`

Some things are still not perfect and need to be updated. More specifically:
* Whenever a refresh happens or a change in filters, the user is set to the first page. To fix this, some sort of queryParams would be required