### PR TITLE
Support tag filtering functionality as URL param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextjs-portofolio-website",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nextjs-portofolio-website",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "dependencies": {
         "@mdx-js/loader": "^3.1.0",
         "@mdx-js/react": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-portofolio-website",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -99,12 +99,14 @@ export default async function BlogPostPage(props: { params: pageParams }) {
             <p className="text-gray-500 mb-8">
                 {new Date(post.date).toLocaleDateString()} • {readingTime} min read
             </p>
+
             {/* Display current blog post tags */}
             <div className="flex flex-wrap gap-2 mb-8 mt-2 justify-center items-center text-center">
                 {post.tags && post.tags.map(tag => (
-                    <BlogTag key={tag} tag={tag}/>
+                    <BlogTag key={tag} tag={tag} href={`/blog/tag/${encodeURIComponent(tag)}`}/>
                 ))}
             </div>
+
             <div className="prose dark:prose-invert max-w-full overflow-hidden">{content}</div>
             <SimilarBlogPosts allPosts={posts} currentPostPlug={slug} maxPosts={3}/>
         </AnimatedArticle>

--- a/src/app/blog/tag/[tag]/page.tsx
+++ b/src/app/blog/tag/[tag]/page.tsx
@@ -20,7 +20,12 @@ export default function BlogTagPage({params}: { params: pageParams & { tag: stri
         post.tags && post.tags.some(t => t.toLowerCase() === decodedTag.toLowerCase())
     );
 
-    // Dice coefficient for string similarity
+    /**
+     * Compute the Dice Coefficient similarity between two strings.
+     * @param a the first string
+     * @param b the second string
+     * @returns a similarity score between 0 and 1 (1 = identical, 0 = no similarity)
+     */
     function diceCoefficient(a: string, b: string): number {
         if (!a.length || !b.length) return 0;
         if (a === b) return 1;
@@ -42,7 +47,13 @@ export default function BlogTagPage({params}: { params: pageParams & { tag: stri
         return (2 * matches) / (pairsA.length + pairsB.length);
     }
 
-    // Find top N posts with tags closest to the requested tag
+    /**
+     * Find posts with tags that are most similar to the target tag using Dice Coefficient.
+     * @param posts the list of blog posts to search
+     * @param targetTag the tag to compare against
+     * @param maxPosts the maximum number of similar posts to return
+     * @returns an array of posts with their best matching tag and similarity score
+     */
     function getClosestTagPosts(posts: BlogPostProps[], targetTag: string, maxPosts: number = 3): Array<{
         post: BlogPostProps;
         bestScore: number;
@@ -88,15 +99,23 @@ export default function BlogTagPage({params}: { params: pageParams & { tag: stri
                     Back to all blog posts
                 </Link>
                 {closestTagPosts.length > 0 && (
-                    <div className="mt-4 w-full max-w-4xl">
-                        <h2 className="text-lg font-semibold mb-2 text-center">You might be interested in these posts
-                            with similar tags:</h2>
+                    <div className="mt-8 w-full max-w-4xl">
+                        <h2 className="text-xl font-bold mb-4 text-center flex flex-col items-center">
+                            <span className="mb-1">You might be interested in these posts
+                            with similar tags:</span>
+                        </h2>
                         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 text-left">
-                            {closestTagPosts.map(({post, bestTag}) => (
-                                <div key={post.slug}>
+                            {closestTagPosts.map(({post, bestTag, bestScore}) => (
+                                <div key={post.slug} className="relative">
                                     <BlogPost {...post} />
-                                    <div className="mt-2 text-xs text-gray-500">Most similar tag: <span
-                                        className="font-semibold text-blue-600">{bestTag}</span></div>
+                                    <div className="mt-4 ml-3 flex items-center gap-2 text-xs text-gray-600">
+                                        <span className="dark:text-white text-black">Reason: </span>
+                                        <FaTag className="w-3 h-3 text-blue-400"/>
+                                        <span
+                                            className="px-2 py-1 rounded-full dark:bg-blue-50 text-blue-700 font-semibold bg-blue-200">{bestTag}
+                                        </span>
+                                        <span className="dark:text-gray-300 text-gray-500">{Math.round(bestScore * 100)}% match</span>
+                                    </div>
                                 </div>
                             ))}
                         </div>

--- a/src/app/blog/tag/[tag]/page.tsx
+++ b/src/app/blog/tag/[tag]/page.tsx
@@ -1,7 +1,8 @@
+import Link from "next/link";
 import posts from '@/data/blog';
 import BlogPost from '@/components/BlogPost';
-import AnimatedArticle from '@/components/AnimatedArticle';
 import {pageParams} from '@/lib/types';
+import {FaTag, FaArrowLeft} from "react-icons/fa";
 
 /**
  * BlogTagPage component that displays blog posts filtered by a specific tag.
@@ -9,31 +10,87 @@ import {pageParams} from '@/lib/types';
  * @param params - The route parameters including the tag to filter by.
  */
 export default function BlogTagPage({params}: { params: pageParams & { tag: string } }) {
-    const {tag} = params;
+    // Decode the tag value to handle spaces and special characters
+    const decodedTag = decodeURIComponent(params.tag);
 
-    // Filter posts by tag (case-insensitive)
+    // Filter posts by tag (case-insensitive, exact match)
     const filteredPosts = posts.filter(post =>
-        post.tags && post.tags.some(t => t.toLowerCase() === tag.toLowerCase())
+        post.tags && post.tags.some(t => t.toLowerCase() === decodedTag.toLowerCase())
     );
 
-    // If no posts are found for the tag, display a message
+    // Similarity function
+    function computeTagSimilarity(postTags: string[], targetTag: string): number {
+        if (!postTags || postTags.length === 0) return 0;
+        // Jaccard similarity: 1 if tag is present, 0 otherwise (since only one tag)
+        return postTags.includes(targetTag) ? 1 : 0;
+    }
+
+    // For suggestions: score posts by tag similarity (excluding exact matches)
+    const similarPosts = posts
+        .filter(post =>
+            post.tags && !post.tags.some(t => t.toLowerCase() === decodedTag.toLowerCase())
+        )
+        .map(post => ({
+            post,
+            score: computeTagSimilarity((post.tags ?? []).map(t => t.toLowerCase()), decodedTag.toLowerCase())
+        }))
+        .filter(({score}) => score > 0)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 3)
+        .map(({post}) => post);
+
+    // If no posts are found for the tag, display a friendly message, link, and suggestions
     if (filteredPosts.length === 0) {
         return (
-            <AnimatedArticle>
-                <h1 className="text-2xl font-bold mb-4">No posts found for tag: {tag}</h1>
-            </AnimatedArticle>
+            <div className="flex flex-col items-center justify-center text-center py-8">
+                <FaTag className="w-8 h-8 text-blue-500 mb-2"/>
+                <h1 className="text-2xl font-bold mb-2">No posts found for tag: <span
+                    className="text-blue-600">{decodedTag}</span></h1>
+
+                {/* Back to main page for blog posts */}
+                <Link href="/blog"
+                      className="inline-flex items-center gap-2 text-blue-500 hover:underline font-medium mb-4">
+                    <FaArrowLeft className="w-4 h-4"/>
+                    Back to all blog posts
+
+                </Link>
+                {similarPosts.length > 0 && (
+                    <div className="mt-4 w-full max-w-2xl">
+                        <h2 className="text-lg font-semibold mb-2">You might be interested in these posts with similar
+                            tags:</h2>
+                        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                            {similarPosts.map(post => (
+                                <BlogPost key={post.slug} {...post} />
+                            ))}
+                        </div>
+                    </div>
+                )}
+            </div>
         );
     }
 
+    // Render the list of posts with the specified tag
     return (
-        <AnimatedArticle>
-            <h1 className="text-2xl font-bold mb-4">Posts tagged with "{tag}"</h1>
-            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <div className="px-4 max-w-4xl mx-auto py-8 flex flex-col">
+            <div className="flex items-center gap-3 mb-6">
+                <FaTag className="w-6 h-6 text-blue-500"/>
+
+                {/* Responsive header: stacked on mobile, inline on md+ */}
+                <div className="flex flex-col md:flex-row md:items-center">
+                    <span className="text-2xl font-bold leading-tight md:mr-2">Posts tagged with</span>
+                    <span className="text-blue-600 text-xl font-bold leading-tight">
+                        &quot;{decodedTag}&quot;
+                        <span className="ml-2 text-base font-semibold text-gray-500 align-middle">
+                            ({filteredPosts.length} post{filteredPosts.length !== 1 ? 's' : ''})
+                        </span>
+                    </span>
+                </div>
+            </div>
+            <div className="grid grid-cols-1 gap-6">
                 {filteredPosts.map(post => (
                     <BlogPost key={post.slug} {...post} />
                 ))}
             </div>
-        </AnimatedArticle>
+        </div>
     );
 }
-

--- a/src/app/blog/tag/[tag]/page.tsx
+++ b/src/app/blog/tag/[tag]/page.tsx
@@ -1,0 +1,39 @@
+import posts from '@/data/blog';
+import BlogPost from '@/components/BlogPost';
+import AnimatedArticle from '@/components/AnimatedArticle';
+import {pageParams} from '@/lib/types';
+
+/**
+ * BlogTagPage component that displays blog posts filtered by a specific tag.
+ * This page is accessed via the "/blog/tag/[tag]" URL.
+ * @param params - The route parameters including the tag to filter by.
+ */
+export default function BlogTagPage({params}: { params: pageParams & { tag: string } }) {
+    const {tag} = params;
+
+    // Filter posts by tag (case-insensitive)
+    const filteredPosts = posts.filter(post =>
+        post.tags && post.tags.some(t => t.toLowerCase() === tag.toLowerCase())
+    );
+
+    // If no posts are found for the tag, display a message
+    if (filteredPosts.length === 0) {
+        return (
+            <AnimatedArticle>
+                <h1 className="text-2xl font-bold mb-4">No posts found for tag: {tag}</h1>
+            </AnimatedArticle>
+        );
+    }
+
+    return (
+        <AnimatedArticle>
+            <h1 className="text-2xl font-bold mb-4">Posts tagged with "{tag}"</h1>
+            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                {filteredPosts.map(post => (
+                    <BlogPost key={post.slug} {...post} />
+                ))}
+            </div>
+        </AnimatedArticle>
+    );
+}
+

--- a/src/components/BlogTag.tsx
+++ b/src/components/BlogTag.tsx
@@ -1,21 +1,36 @@
+import Link from 'next/link';
 import {FaTag} from "react-icons/fa";
 
 /**
  * A functional component that renders a blog tag with an icon and the tag name.
- * @param tag the name of the tag to display
+ * @param tag - The name of the tag to display
+ * @param href - Optional link to make the tag clickable
  */
-export default function BlogTag({tag}: { tag: string }) {
-    return (
+export default function BlogTag({tag, href}: { tag: string, href?: string }) {
+
+    // Base styles for the tag
+    const baseClasses = `
+        flex items-center text-xs bg-blue-100 text-blue-700 dark:bg-blue-900
+        dark:text-blue-300 px-3 py-1 rounded-full transition duration-300 cursor-pointer
+    `;
+
+    // Hover effects for the tag (if it's a link)
+    const hoverClasses = `
+        hover:scale-105 hover:bg-blue-200 hover:shadow-md dark:hover:bg-blue-800
+    `;
+
+    const content = (
         <span
-            key={tag}
-            className={`
-            flex items-center text-xs bg-blue-100 text-blue-700 dark:bg-blue-900
-            dark:text-blue-300 px-2 py-1 rounded-full group-hover:bg-blue-200 dark:hover:bg-blue-900
-            dark:group-hover:bg-blue-900
-            transition duration-300`}
+            className={href ? `${baseClasses} ${hoverClasses}` : baseClasses}
         >
             <FaTag className="w-3 h-3 mr-1"/>
             {tag}
         </span>
-    )
+    );
+
+    return href ? (
+        <Link href={href}>
+            {content}
+        </Link>
+    ) : content;
 }

--- a/src/data/blog/post5.mdx
+++ b/src/data/blog/post5.mdx
@@ -28,6 +28,8 @@ CSS Grid is a **layout system** for CSS that gives you control over both rows an
 }
 ```
 
+And the HTML:
+
 ```html
 <div class="container">
   <div>1</div>


### PR DESCRIPTION
Adds the functionality to search posts that contain a particular tag using URL. For example, /blogs/tag/frontend would return:

<img width="917" height="724" alt="image" src="https://github.com/user-attachments/assets/91609fc6-53b7-4af2-8f1f-b3a168ac8d0a" />

And when the tag does not exist, we try to display the 3 most similar posts that do have a tag similar to the one you provided:

<img width="948" height="586" alt="image" src="https://github.com/user-attachments/assets/cbe18f56-89d3-4b5c-88c6-2e887817cb82" />
