### PR TITLE
feat: better contrast and improved image carousel

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -54,7 +54,7 @@ export default function Footer() {
       className={cn(
         "relative mt-6 py-6 text-center text-sm text-gray-600 dark:text-gray-400",
         "px-4 border-t border-gray-200 dark:border-gray-900",
-        "bg-zinc-50/80 dark:bg-black/80 backdrop-blur-sm",
+        "bg-zinc-50/80 dark:bg-zinc-950/80 backdrop-blur-sm",
         "before:content-[''] before:absolute before:top-0 before:left-0 before:right-0",
         "before:h-px before:bg-linear-to-r before:from-transparent",
         "before:via-gray-500/30 before:to-transparent"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -28,7 +28,7 @@ export default function Header() {
       className={cn(
         "sticky top-0 z-50 w-full transition-all duration-300",
         "text-black dark:text-white",
-        "bg-zinc-50/90 dark:bg-black/90",
+        "bg-zinc-50/90 dark:bg-zinc-950/90",
         "border-b border-gray-300 dark:border-gray-800",
         "backdrop-blur-md backdrop-saturate-150",
         "shadow-sm hover:shadow-md"

--- a/src/components/ProjectImageCarousel.tsx
+++ b/src/components/ProjectImageCarousel.tsx
@@ -76,20 +76,27 @@ export default function ProjectImageCarousel({ images }: ProjectImageCarouselPro
             <FaChevronLeft className="w-3 h-3" />
           </button>
 
-          <div className="flex items-center gap-2">
-            {images.map((_, index) => (
-              <button
-                key={index}
-                onClick={() => api?.scrollTo(index)}
-                className={`h-2 rounded-full transition-all ${
-                  index === current
-                    ? "w-8 bg-accent-500"
-                    : "w-2 bg-gray-300 dark:bg-gray-600 hover:bg-gray-400 dark:hover:bg-gray-500"
-                }`}
-                aria-label={`Go to slide ${index + 1}`}
-              />
-            ))}
-          </div>
+          {/* When fewer than 8 imgs, show pill indicators; otherwise show "current / total" */}
+          {images.length <= 8 ? (
+            <div className="flex items-center gap-2">
+              {images.map((_, index) => (
+                <button
+                  key={index}
+                  onClick={() => api?.scrollTo(index)}
+                  className={`h-2 rounded-full transition-all ${
+                    index === current
+                      ? "w-8 bg-accent-500"
+                      : "w-2 bg-gray-300 dark:bg-gray-600 hover:bg-gray-400 dark:hover:bg-gray-500"
+                  }`}
+                  aria-label={`Go to slide ${index + 1}`}
+                />
+              ))}
+            </div>
+          ) : (
+            <span className="text-sm tabular-nums text-gray-500 dark:text-gray-400 min-w-12 text-center">
+              {current + 1} / {images.length}
+            </span>
+          )}
 
           <button
             onClick={() => api?.scrollNext()}

--- a/src/components/ProjectImageCarousel.tsx
+++ b/src/components/ProjectImageCarousel.tsx
@@ -2,14 +2,9 @@
 
 import Image from "next/image"
 import React, { useCallback, useEffect, useState } from "react"
-import {
-  Carousel,
-  CarouselApi,
-  CarouselContent,
-  CarouselItem,
-  CarouselNext,
-  CarouselPrevious,
-} from "@/components/ui/carousel"
+import { FaChevronLeft, FaChevronRight } from "react-icons/fa"
+import { Carousel, CarouselApi, CarouselContent, CarouselItem } from "@/components/ui/carousel"
+import { cn } from "@/lib/utils"
 
 interface ProjectImageCarouselProps {
   images: { src: string; alt: string }[]
@@ -64,25 +59,49 @@ export default function ProjectImageCarousel({ images }: ProjectImageCarouselPro
             </CarouselItem>
           ))}
         </CarouselContent>
-        <CarouselPrevious className="left-2 md:left-4" />
-        <CarouselNext className="right-2 md:right-4" />
       </Carousel>
 
-      {/* Pill indicators */}
+      {/* Controls: prev button, pill indicators, next button */}
       {images.length > 1 && (
-        <div className="flex justify-center gap-2 mt-4">
-          {images.map((_, index) => (
-            <button
-              key={index}
-              onClick={() => api?.scrollTo(index)}
-              className={`h-2 rounded-full transition-all ${
-                index === current
-                  ? "w-8 bg-accent-500"
-                  : "w-2 bg-gray-300 dark:bg-gray-600 hover:bg-gray-400 dark:hover:bg-gray-500"
-              }`}
-              aria-label={`Go to slide ${index + 1}`}
-            />
-          ))}
+        <div className="flex items-center justify-center gap-3 mt-4">
+          <button
+            onClick={() => api?.scrollPrev()}
+            className={cn(
+              "flex items-center justify-center w-7 h-7 rounded-full cursor-pointer border",
+              "border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-600",
+              "dark:text-gray-300 hover:border-accent-500 hover:text-accent-500 transition-all"
+            )}
+            aria-label="Previous slide"
+          >
+            <FaChevronLeft className="w-3 h-3" />
+          </button>
+
+          <div className="flex items-center gap-2">
+            {images.map((_, index) => (
+              <button
+                key={index}
+                onClick={() => api?.scrollTo(index)}
+                className={`h-2 rounded-full transition-all ${
+                  index === current
+                    ? "w-8 bg-accent-500"
+                    : "w-2 bg-gray-300 dark:bg-gray-600 hover:bg-gray-400 dark:hover:bg-gray-500"
+                }`}
+                aria-label={`Go to slide ${index + 1}`}
+              />
+            ))}
+          </div>
+
+          <button
+            onClick={() => api?.scrollNext()}
+            className={cn(
+              "flex items-center justify-center w-7 h-7 rounded-full cursor-pointer border",
+              "border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-600",
+              "dark:text-gray-300 hover:border-accent-500 hover:text-accent-500 transition-all"
+            )}
+            aria-label="Next slide"
+          >
+            <FaChevronRight className="w-3 h-3" />
+          </button>
         </div>
       )}
     </div>

--- a/src/components/ProjectImageCarousel.tsx
+++ b/src/components/ProjectImageCarousel.tsx
@@ -86,7 +86,7 @@ export default function ProjectImageCarousel({ images }: ProjectImageCarouselPro
                   className={`h-2 rounded-full transition-all ${
                     index === current
                       ? "w-8 bg-accent-500"
-                      : "w-2 bg-gray-300 dark:bg-gray-600 hover:bg-gray-400 dark:hover:bg-gray-500"
+                      : "size-2 bg-gray-300 dark:bg-gray-600 hover:bg-gray-400 dark:hover:bg-gray-500 cursor-pointer hover:scale-120"
                   }`}
                   aria-label={`Go to slide ${index + 1}`}
                 />

--- a/tests/components/ProjectImageCarousel.test.tsx
+++ b/tests/components/ProjectImageCarousel.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+import React from "react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import ProjectImageCarousel from "@/components/ProjectImageCarousel"
+
+// Embla mock-related functions and state
+const mockScrollPrev = vi.fn()
+const mockScrollNext = vi.fn()
+const mockScrollTo = vi.fn()
+const mockSelectedScrollSnap = vi.fn(() => 0)
+const mockOn = vi.fn()
+const mockOff = vi.fn()
+
+const mockApi = {
+  scrollPrev: mockScrollPrev,
+  scrollNext: mockScrollNext,
+  scrollTo: mockScrollTo,
+  selectedScrollSnap: mockSelectedScrollSnap,
+  canScrollPrev: vi.fn(() => false),
+  canScrollNext: vi.fn(() => false),
+  on: mockOn,
+  off: mockOff,
+}
+
+vi.mock("embla-carousel-react", () => ({
+  default: () => [vi.fn(), mockApi],
+}))
+
+// Fixture data
+const ONE_IMAGE = [{ src: "/a.jpg", alt: "Alpha" }]
+const TWO_IMAGES = [
+  { src: "/a.jpg", alt: "Alpha" },
+  { src: "/b.jpg", alt: "Beta" },
+]
+const EIGHT_IMAGES = Array.from({ length: 8 }, (_, i) => ({
+  src: `/img${i + 1}.jpg`,
+  alt: `Image ${i + 1}`,
+}))
+const NINE_IMAGES = Array.from({ length: 9 }, (_, i) => ({
+  src: `/img${i + 1}.jpg`,
+  alt: `Image ${i + 1}`,
+}))
+
+describe("ProjectImageCarousel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSelectedScrollSnap.mockReturnValue(0)
+  })
+
+  it("renders nothing when the images array is empty", () => {
+    const { container } = render(<ProjectImageCarousel images={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders all images with their alt text", () => {
+    render(<ProjectImageCarousel images={TWO_IMAGES} />)
+    expect(screen.getByAltText("Alpha")).toBeDefined()
+    expect(screen.getByAltText("Beta")).toBeDefined()
+  })
+
+  it("does not render navigation controls for a single image", () => {
+    render(<ProjectImageCarousel images={ONE_IMAGE} />)
+    expect(screen.queryByLabelText("Previous slide")).toBeNull()
+    expect(screen.queryByLabelText("Next slide")).toBeNull()
+  })
+
+  it("renders prev/next buttons when there are multiple images", () => {
+    render(<ProjectImageCarousel images={TWO_IMAGES} />)
+    expect(screen.getByLabelText("Previous slide")).toBeDefined()
+    expect(screen.getByLabelText("Next slide")).toBeDefined()
+  })
+
+  it("calls scrollPrev when the previous button is clicked", () => {
+    render(<ProjectImageCarousel images={TWO_IMAGES} />)
+    fireEvent.click(screen.getByLabelText("Previous slide"))
+    expect(mockScrollPrev).toHaveBeenCalledOnce()
+  })
+
+  it("calls scrollNext when the next button is clicked", () => {
+    render(<ProjectImageCarousel images={TWO_IMAGES} />)
+    fireEvent.click(screen.getByLabelText("Next slide"))
+    expect(mockScrollNext).toHaveBeenCalledOnce()
+  })
+
+  describe("pill indicators (≤ 8 images)", () => {
+    it("renders one pill per image", () => {
+      render(<ProjectImageCarousel images={EIGHT_IMAGES} />)
+      EIGHT_IMAGES.forEach((_, i) => {
+        expect(screen.getByLabelText(`Go to slide ${i + 1}`)).toBeDefined()
+      })
+    })
+
+    it("calls scrollTo with the correct index when a pill is clicked", () => {
+      render(<ProjectImageCarousel images={TWO_IMAGES} />)
+      fireEvent.click(screen.getByLabelText("Go to slide 2"))
+      expect(mockScrollTo).toHaveBeenCalledWith(1)
+    })
+  })
+
+  describe("numeric counter (> 8 images)", () => {
+    it("shows a counter instead of pills", () => {
+      render(<ProjectImageCarousel images={NINE_IMAGES} />)
+      expect(screen.queryByLabelText("Go to slide 1")).toBeNull()
+      expect(screen.getByText(/1 \/ 9/)).toBeDefined()
+    })
+  })
+})


### PR DESCRIPTION
## Description

[//]: # "Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context."

This PR adds the following changes:
- Better contrast for header and footer components on dark mode.
- Fixes the project's image carousel component to show left/right arrow buttons together with the pill layout. Also, when there are too many pills (more than 8) we show X / N instead to not cause spillage (i.e., overflow).

## Type of Change

[//]: # "Please select one"

- [X] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

[//]: # "Please check all that apply"

- [X] Manually tested by running `pnpm dev` and viewing all pages
- [X] It can build a prod build with `pnpm build`
- [X] Documentation and comments added
- [X] No console warnings or errors
- [X] No ESLint warnings or errors
- [X] No prettier warnings or errors
- [X] No vitest warnings or errors

## Supplementary Information

[//]: # "Any other information that is important to this PR, such as screenshots of a UI change"

<img width="862" height="149" alt="image" src="https://github.com/user-attachments/assets/e0466e44-59bd-4a68-b5bf-ecf540d0e4a7" />
