### PR TITLE
feat: add json-ld structured data on blog posts, projects, work, & home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,12 @@ point for your own personal website, or as a reference for doing the same thing 
 - [Zod](https://zod.dev/)-validated frontmatter for all MDX content types. Invalid files are caught at build time with
   precise field-level error messages
 - Syntax highlighting for code blocks in MDX files
-- Light/dark mode toggle
+- Light/dark mode toggle. The classic theme switcher ;)
 - Responsive design for mobile and desktop
-- SEO-friendly structure and metadata
+- SEO-friendly structure and metadata,
+  including [JSON-LD structured data](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data)
+  on the home page and blog posts for Google rich results eligibility. For more context, also see
+  Vercel's [JSON-LD guide](https://nextjs.org/docs/app/guides/json-ld).
 - SSR support for pagination, sorting, and filtering of blog posts, projects, and work items
 - Similar blog posts recommendations
 - Blog post categories pages

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ point for your own personal website, or as a reference for doing the same thing 
 - [🧱 Project Structure](#-project-structure)
 - [🚀 Getting Started](#-getting-started)
 - [🎨 Customization](#-customization)
-- [🖼️ Open Graph Images](#-open-graph-images)
+- [🔍 SEO](#-seo)
 - [🧭 Roadmap](#-roadmap)
 - [📚 Learn More](#-learn-more)
 - [▲ Deployment](#-deployment)
@@ -212,11 +212,15 @@ components or understand the codebase!
 
 ---
 
-## 🖼️ Open Graph Images
+## 🔍 SEO
 
-Dynamic Open Graph images are automatically generated for every content page using Next.js's built-in `ImageResponse`
-API. When someone shares a link on social media or a messaging app, they get a branded preview image instead of a blank
-card.
+This template ships with a comprehensive SEO setup out of the box: global metadata, Open Graph and Twitter Card tags,
+dynamic OG image generation, JSON-LD structured data, a sitemap, a `robots.txt`, an RSS feed, and an `llms.txt` route.
+
+### Dynamic Open Graph images
+
+Per-page Open Graph images are generated at build time using Next.js's built-in `ImageResponse` API. When someone shares
+a link on social media or a messaging app, they get a branded preview image instead of a blank card.
 
 | Blog post                                       | Work item                                       | Project                                               |
 |-------------------------------------------------|-------------------------------------------------|-------------------------------------------------------|
@@ -226,8 +230,6 @@ card.
 |-----------------------------------------------|-|
 | ![Tag OG example](public/og-examples/tag.png) | |
 
-### Covered routes
-
 | Route              | Image content                                          |
 |--------------------|--------------------------------------------------------|
 | `/blog/[slug]`     | Post title, summary, tags, and date                    |
@@ -236,22 +238,10 @@ card.
 | `/projects/[slug]` | Project title, description, tech stack, and duration   |
 
 The homepage uses the static image at `/public/og-image.png` (configured via `siteMetadata.ogImage` in
-`src/data/metadata.ts`).
+`src/data/metadata.ts`). All generated images pick up the accent color from `siteMetadata.theme`. Changing the theme
+updates the color across the entire site _and_ in all OG images automatically.
 
-### Theme
-
-All generated images pick up the accent color from `siteMetadata.theme` in `src/data/metadata.ts`. Changing the theme
-there updates the accent color across the entire site _and_ in all OG images. No other changes needed. The available
-themes are: `blue`, `purple`, `green`, `orange`, `rose`, `teal`, `indigo`, `amber`, `cyan`, and `violet`.
-
-### When are images generated?
-
-Images are generated at **build time** and cached. Since all content comes from MDX files on disk, a rebuild is always
-required to publish new content anyway, so the images are always up to date after each deployment.
-
-### Local preview
-
-With the dev server running, you can view any generated image directly in a browser:
+Images are generated at **build time** and cached. With the dev server running, you can preview any of them directly:
 
 ```
 http://localhost:3000/blog/your-post-slug/opengraph-image
@@ -259,6 +249,12 @@ http://localhost:3000/blog/tag/typescript/opengraph-image
 http://localhost:3000/work/your-company-slug/opengraph-image
 http://localhost:3000/projects/your-project-slug/opengraph-image
 ```
+
+### Full SEO reference
+
+For a complete breakdown of every SEO feature and the steps you need to take when customizing the template (setting your
+domain, replacing assets, submitting to Google Search Console, validating structured data, etc.),
+see **[docs/SEO.md](docs/SEO.md)**.
 
 ---
 

--- a/docs/SEO.md
+++ b/docs/SEO.md
@@ -1,0 +1,146 @@
+# SEO Guide
+
+This document covers all SEO features built into the template and the steps you need to take when customizing it.
+
+---
+
+## What's included out of the box
+
+### Global metadata (`src/data/metadata.ts`)
+
+All SEO-relevant metadata is centralized in `src/data/metadata.ts` and applied globally via Next.js's `<head>`:
+
+- **Page title and description**: used by search engines and displayed in result snippets
+- **Keywords**: meta keywords array
+- **Author / creator / publisher** fields
+- **Canonical URL**: set via `metadataBase` and `alternates.canonical`
+- **Robots directives**: `index: true`, `follow: true`, with fine-grained Googlebot settings (no limits on snippet,
+  image preview, or video preview length)
+- **Favicon and Apple touch icon**: served from `/public/icons/`
+
+### Open Graph and Twitter Card tags
+
+Every page emits Open Graph and Twitter Card tags for rich link previews on social media platforms. The global defaults
+come from `metadata.ts`; individual content pages (`/blog/[slug]`, `/projects/[slug]`, `/work/[slug]`) override title
+and description with their own values.
+
+### Dynamic OG image generation
+
+Per-page Open Graph images are generated at build time using Next.js `ImageResponse`. Each image picks up the accent
+color configured in `siteMetadata.theme`.
+
+| Route              | Image content                                       |
+|--------------------|-----------------------------------------------------|
+| `/blog/[slug]`     | Post title, summary, up to 4 tags, publication date |
+| `/blog/tag/[tag]`  | Tag name, post count, latest 3 post titles          |
+| `/work/[slug]`     | Company name, role, description, period, locations  |
+| `/projects/[slug]` | Project title, description, tech stack, duration    |
+
+The home page (`/`) uses the static image at `/public/og-image.png`.
+
+### JSON-LD structured data
+
+Schema.org structured data is embedded in a `<script type="application/ld+json">` tag on every major page, making
+content eligible for Google rich results:
+
+| Page               | Schema type           | Key fields                                                   |
+|--------------------|-----------------------|--------------------------------------------------------------|
+| Home (`/`)         | `Person`              | Name, job title, site URL, social profile links (`sameAs`)   |
+| `/blog/[slug]`     | `BlogPosting`         | Headline, summary, publish date, tags as keywords, author    |
+| `/projects/[slug]` | `SoftwareApplication` | Name, description, dates, tech stack as keywords, GitHub URL |
+| `/work/[slug]`     | `EmployeeRole`        | Role name, company, description, start/end dates             |
+
+Types are enforced via the [`schema-dts`](https://github.com/google/schema-dts) package.
+
+### `sitemap.xml`
+
+A `sitemap.xml` is generated automatically at `/sitemap.xml` (via `src/app/sitemap.ts`). It covers the four main
+routes: home, `/work`, `/projects`, `/blog`, with appropriate `changeFrequency` and `priority` values.
+That said, these change frequency and priority hints are just that: hints. Search engines may choose to ignore them
+and instead crawl based on internal linking structure and their own algorithms.
+
+### `robots.txt`
+
+A `robots.txt` is generated automatically at `/robots.txt` (via `src/app/robots.ts`). It allows all crawlers on `/` and
+disallows `/api/`, `/_next/`, and `/private/`. The sitemap URL is included.
+
+### RSS feed
+
+A full RSS feed is available at `/rss.xml` and is advertised in the `<head>` via an `application/rss+xml` `alternates`
+link. It is built from all blog posts in `src/data/blog/`.
+
+### `llms.txt`
+
+A `/llms.txt` route is generated from content metadata to help AI agents and LLM crawlers discover and understand the
+site's content structure.
+
+### Per-page `<title>` and `<meta description>`
+
+Each dynamic content page (`/blog/[slug]`, `/projects/[slug]`, `/work/[slug]`) generates its own `<title>` and
+`<meta name="description">` via Next.js `generateMetadata`, overriding the global defaults.
+
+---
+
+## Steps to take when customizing the template
+
+### 1. Fill in `src/data/metadata.ts`
+
+This is the single most important file for SEO. Update every field:
+
+```ts
+export const siteMetadata = {
+    title: "Your Name – Developer Portfolio",
+    description: "Short, compelling description of your work (≤ 160 chars).",
+    keywords: ["Your Name", "Software Engineer", "React", ...],
+    author: {
+        name: "Your Name",
+        url: "https://yourdomain.com",
+    },
+    siteUrl: "https://yourdomain.com",   // or set NEXT_PUBLIC_SITE_URL in .env.local
+    social: {
+        twitter: "@yourhandle",
+    },
+    ogImage: "/og-image.png",
+}
+```
+
+`siteUrl` is used in canonical URLs, sitemap entries, and JSON-LD `url` fields, so make sure it matches your actual
+deployed domain exactly (no trailing slash).
+
+### 2. Replace the static OG image
+
+Create a 1200×630 px image and place it at `/public/og-image.png`. This image is used as the fallback for the home page
+and any page without a dynamically generated image.
+
+### 3. Replace the favicon
+
+Replace `/public/icons/favicon.ico` with your own icon. If you add additional formats (`.png`, `.svg`), update the
+`icons` object in `metadata.ts` to point to them.
+
+### 4. Update social links in `src/data/content.ts`
+
+The `Person` JSON-LD on the home page reads its `sameAs` links from `footerConfig.socialLinks`. Fill in your actual
+profile URLs. Any field left empty (`""`) is automatically excluded from the structured data.
+
+### 5. Populate `siteUrl` before deploying
+
+Before your first deployment, set `NEXT_PUBLIC_SITE_URL` in your hosting environment (e.g. a Vercel environment
+variable) or hardcode it in `metadata.ts`. Canonical URLs and sitemap entries will be wrong if this is left as the
+default placeholder.
+
+### 6. Submit your sitemap to Google Search Console
+
+Once deployed, go to [Google Search Console](https://search.google.com/search-console) --> Sitemaps, and submit
+`https://yourdomain.com/sitemap.xml`. This accelerates indexing.
+
+### 7. Validate structured data
+
+Use [Google's Rich Results Test](https://search.google.com/test/rich-results) or
+the [Schema Markup Validator](https://validator.schema.org/) to verify that JSON-LD on each page is parsed correctly.
+Paste the page URL or the raw JSON.
+
+### 8. Keep the sitemap in sync with new routes
+
+`src/app/sitemap.ts` currently lists only the four top-level routes. If you add new static pages, add them there.
+Individual blog/project/work slugs do not need to be listed, since search engines follow internal links, and the OG
+metadata on each page is sufficient for indexing.

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint-config-prettier": "10.1.8",
     "jsdom": "^28.1.0",
     "prettier": "3.8.3",
+    "schema-dts": "^2.0.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       prettier:
         specifier: 3.8.3
         version: 3.8.3
+      schema-dts:
+        specifier: ^2.0.0
+        version: 2.0.0(typescript@5.9.3)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -2752,6 +2755,15 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  schema-dts-lib@1.0.0:
+    resolution: {integrity: sha512-9MEO5vpQH9JdBioUupqluzxSYxPLjhmqRUudk15adUl/ypnRsM2/M1kN3AmVJQeG7nZqcL68H8JlGqQQT6vy9A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+
+  schema-dts@2.0.0:
+    resolution: {integrity: sha512-t7NoCy3Rn5GHGx6p7s1qIYK/AeIb8ZxJNR9WUNFkwMv2CiiGZBmqqYWc2FlZVm5ZbiHMY4OvBWhj7QtyrFO2Jw==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -6242,6 +6254,16 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
+
+  schema-dts-lib@1.0.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  schema-dts@2.0.0(typescript@5.9.3):
+    dependencies:
+      schema-dts-lib: 1.0.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
 
   semver@6.3.1: {}
 

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -18,9 +18,11 @@ import { InlineCode } from "@/components/mdx/InlineCode"
 import SimilarBlogPosts from "@/components/SimilarBlogPosts"
 import TableOfContents from "@/components/TableOfContents"
 import { homeIntroConfig } from "@/data/content"
+import { siteMetadata } from "@/data/metadata"
 import { getAllBlogPosts } from "@/lib/mdx"
 import { pageParams } from "@/lib/types"
 import { getReadingTime } from "@/lib/utils"
+import type { BlogPosting, WithContext } from "schema-dts"
 
 /**
  * Generate static parameters for the blog post pages to be pre-rendered.
@@ -122,8 +124,32 @@ export default async function BlogPostPage(props: { params: pageParams }) {
     components: mdxComponents,
   })
 
+  const jsonLd: WithContext<BlogPosting> = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.title,
+    description: post.summary,
+    datePublished: post.date,
+    url: `${siteMetadata.siteUrl}/blog/${post.slug}`,
+    ...(post.tags && post.tags.length > 0 && { keywords: post.tags.join(", ") }),
+    author: {
+      "@type": "Person",
+      name: homeIntroConfig.name,
+      url: siteMetadata.siteUrl,
+    },
+    publisher: {
+      "@type": "Person",
+      name: homeIntroConfig.name,
+      url: siteMetadata.siteUrl,
+    },
+  }
+
   return (
     <AnimatedArticle>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c") }}
+      />
       <BackToPageButton pageUrl="/blog" />
       <div className="text-3xl font-bold mb-4">{post.title}</div>
       <div className="flex items-center gap-4 text-gray-500 mb-8">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,43 @@
 import HomeContent from "@/components/home/HomeContent"
+import { footerConfig, homeIntroConfig } from "@/data/content"
+import { siteMetadata } from "@/data/metadata"
 import { getAllBlogPosts, getAllProjects, getAllWorkItems } from "@/lib/mdx"
+import type { Person, WithContext } from "schema-dts"
 
 /**
  * Home component that serves as the main landing page for the portfolio.
  * This is accessed at the root URL ("/") of the application.
  * This is a server component wrapper that fetches data and passes it to the client HomeContent component.
+ * It also generates JSON-LD structured data for SEO purposes, describing the person (author) and their social links.
+ * The JSON-LD is included in a script tag in the head of the page, and it uses the schema.org "Person" type to describe the author.
+ * The "sameAs" property includes links to social media profiles, which can help search engines understand the author's online presence.
  */
 export default async function Home() {
-  // Fetch all blog posts, work items, and projects from MDX files
-  const blog = await getAllBlogPosts()
-  const work = await getAllWorkItems()
-  const projects = await getAllProjects()
+  const [blog, work, projects] = await Promise.all([
+    getAllBlogPosts(),
+    getAllWorkItems(),
+    getAllProjects(),
+  ])
 
-  return <HomeContent blog={blog} work={work} projects={projects} />
+  const sameAs = Object.values(footerConfig.socialLinks).filter(url => url && url !== "/")
+
+  const jsonLd: WithContext<Person> = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: siteMetadata.author.name,
+    url: siteMetadata.siteUrl,
+    description: siteMetadata.description,
+    jobTitle: homeIntroConfig.facts.role,
+    ...(sameAs.length > 0 && { sameAs }),
+  }
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c") }}
+      />
+      <HomeContent blog={blog} work={work} projects={projects} />
+    </>
+  )
 }

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -13,9 +13,11 @@ import BackToPageButton from "@/components/BackToPageButton"
 import ProjectImageCarousel from "@/components/ProjectImageCarousel"
 import TechBadge from "@/components/TechBadge"
 import { homeIntroConfig } from "@/data/content"
+import { siteMetadata } from "@/data/metadata"
 import { getAllProjects } from "@/lib/mdx"
 import { pageParams, ProjectFrontmatter } from "@/lib/types"
 import { formatDuration } from "@/lib/utils"
+import type { SoftwareApplication, WithContext } from "schema-dts"
 
 /**
  * Generate static parameters for the project pages to be pre-rendered.
@@ -54,6 +56,9 @@ export async function generateMetadata(props: { params: pageParams }): Promise<M
 
 /**
  * ProjectPage component that renders a single project based on the slug.
+ * It also generates JSON-LD structured data for SEO purposes, describing the software application (project) and its attributes.
+ * The JSON-LD uses the schema.org "SoftwareApplication" type to describe the project, including properties like name, description, URL, dates, tech stack, and author information.
+ * The JSON-LD is included in a script tag in the head of the page, and it is properly escaped to prevent XSS vulnerabilities.
  */
 export default async function ProjectPage(props: { params: pageParams }) {
   const { slug } = await props.params
@@ -100,8 +105,30 @@ export default async function ProjectPage(props: { params: pageParams }) {
     })
   }
 
+  const jsonLd: WithContext<SoftwareApplication> = {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: frontmatter.title,
+    description: frontmatter.description,
+    url: `${siteMetadata.siteUrl}/projects/${post.slug}`,
+    dateCreated: frontmatter.startDate,
+    dateModified: frontmatter.endDate,
+    ...(frontmatter.techStack &&
+      frontmatter.techStack.length > 0 && { keywords: frontmatter.techStack.join(", ") }),
+    ...(frontmatter.githubUrl && { codeRepository: frontmatter.githubUrl }),
+    author: {
+      "@type": "Person",
+      name: homeIntroConfig.name,
+      url: siteMetadata.siteUrl,
+    },
+  }
+
   return (
     <AnimatedArticle>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c") }}
+      />
       <BackToPageButton pageUrl="/projects" />
 
       {/* Header */}

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -13,9 +13,11 @@ import BackToPageButton from "@/components/BackToPageButton"
 import { Timeline, TimelineItem } from "@/components/mdx/Timeline"
 import TechBadge from "@/components/TechBadge"
 import { homeIntroConfig } from "@/data/content"
+import { siteMetadata } from "@/data/metadata"
 import { getAllWorkItems } from "@/lib/mdx"
 import { pageParams, WorkItemFrontmatter } from "@/lib/types"
 import { calculateDuration } from "@/lib/utils"
+import type { EmployeeRole, WithContext } from "schema-dts"
 
 /**
  * Generate static parameters for the work item pages to be pre-rendered.
@@ -75,6 +77,7 @@ function CompanyHeader({ frontmatter }: { frontmatter: WorkItemFrontmatter }) {
 /**
  * WorkItemPage component that renders a single work item based on the slug.
  * It reads the corresponding MDX file, compiles it, and displays the content along with the frontmatter information.
+ * This page also includes structured data in JSON-LD format for SEO purposes, describing the work experience as an EmployeeRole.
  */
 export default async function WorkItemPage(props: { params: pageParams }) {
   const { slug } = await props.params
@@ -105,8 +108,23 @@ export default async function WorkItemPage(props: { params: pageParams }) {
     },
   })
 
+  const jsonLd: WithContext<EmployeeRole> = {
+    "@context": "https://schema.org",
+    "@type": "EmployeeRole",
+    roleName: frontmatter.title,
+    name: frontmatter.company,
+    description: frontmatter.description,
+    startDate: frontmatter.start,
+    ...(frontmatter.end !== "Present" && { endDate: frontmatter.end }),
+    url: `${siteMetadata.siteUrl}/work/${post.slug}`,
+  }
+
   return (
     <AnimatedArticle>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c") }}
+      />
       <BackToPageButton pageUrl="/work" />
       <div className="flex items-center gap-4 mb-2">
         {frontmatter.companyUrl ? (


### PR DESCRIPTION
## Description

Adds JSON-LD structured data (application/ld+json) to all major content pages to improve SEO and enable rich search results. Each page uses the most semantically appropriate schema.org type:

  - Home page (/): `Person` schema with name, job title, URL, and social links
  - Blog posts (`/blog/[slug]`): `BlogPosting` schema with title, summary, publish date, tags, and author
  - Project pages (`/projects/[slug]`):  `SoftwareApplication` schema with name, description, dates, tech stack as keywords, and GitHub repo link
  - Work pages (`/work/[slug]`): `EmployeeRole` schema with role name, company, description, start/end dates (omitting endDate when "Present"), and page URL

All structured data is rendered as a `<script type="application/ld+json">` tag server-side via Next.js RSC pages. The schema-dts package was added to provide TypeScript types for schema.org entities.

## Type of Change

  - [x] Feature

## Checklist
  
  - [X] Manually tested by running pnpm dev and viewing all pages
  - [X] It can build a prod build with pnpm build
  - [x] Documentation and comments added
  - [x] No console warnings or errors
  - [x] No ESLint warnings or errors
  - [x] No prettier warnings or errors
  - [x] No vitest warnings or errors
  
## Supplementary Information

Structured data can be validated using Google's Rich Results Test or the Schema Markup Validator against each page URL once deployed.
