### PR TITLE
feat: add automatic sitemap.xml generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ point for your own personal website, or as a reference for doing the same thing 
 - SEO-friendly structure and metadata,
   including [JSON-LD structured data](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data)
   on the home page and blog posts for Google rich results eligibility. For more context, also see
-  Vercel's [JSON-LD guide](https://nextjs.org/docs/app/guides/json-ld).
+  Vercel's [JSON-LD guide](https://nextjs.org/docs/app/guides/json-ld)
+- Automatic `sitemap.xml` that discovers every blog post, project, work item, and tag page at build time. No
+  manual updates needed when content is added or removed! (See `src/app/sitemap.ts` for implementation details)
 - SSR support for pagination, sorting, and filtering of blog posts, projects, and work items
 - Similar blog posts recommendations
 - Blog post categories pages

--- a/docs/SEO.md
+++ b/docs/SEO.md
@@ -54,10 +54,23 @@ Types are enforced via the [`schema-dts`](https://github.com/google/schema-dts) 
 
 ### `sitemap.xml`
 
-A `sitemap.xml` is generated automatically at `/sitemap.xml` (via `src/app/sitemap.ts`). It covers the four main
-routes: home, `/work`, `/projects`, `/blog`, with appropriate `changeFrequency` and `priority` values.
-That said, these change frequency and priority hints are just that: hints. Search engines may choose to ignore them
-and instead crawl based on internal linking structure and their own algorithms.
+A `sitemap.xml` is generated automatically at `/sitemap.xml` (via `src/app/sitemap.ts`). It covers every
+publicly routable URL on the site. No manual updates needed when you add/remove new content:
+
+| Entries                       | Source                                | `changeFrequency`               | `priority` |
+|-------------------------------|---------------------------------------|---------------------------------|------------|
+| `/`                           | Static                                | `weekly`                        | `1.0`      |
+| `/work`, `/projects`, `/blog` | Static                                | `yearly` / `monthly` / `weekly` | `0.8`      |
+| `/blog/[slug]`                | All MDX files in `src/data/blog/`     | `monthly`                       | `0.6`      |
+| `/blog/tag/[tag]`             | Unique tags across all posts          | `weekly`                        | `0.5`      |
+| `/work/[slug]`                | All MDX files in `src/data/work/`     | `yearly`                        | `0.6`      |
+| `/projects/[slug]`            | All MDX files in `src/data/projects/` | `monthly`                       | `0.6`      |
+
+Blog post entries use the post's `date` frontmatter field as `lastModified`; project entries use `endDate`.
+
+The `change frequency` and `priority` hints are just that: hints. Search engines may choose to ignore them
+and instead crawl based on internal linking structure and their own algorithms. In reality, the actual change
+frequency may, of course, vary widely based on how often you add new content or update existing pages.
 
 ### `robots.txt`
 
@@ -141,6 +154,10 @@ Paste the page URL or the raw JSON.
 
 ### 8. Keep the sitemap in sync with new routes
 
-`src/app/sitemap.ts` currently lists only the four top-level routes. If you add new static pages, add them there.
-Individual blog/project/work slugs do not need to be listed, since search engines follow internal links, and the OG
-metadata on each page is sufficient for indexing.
+`src/app/sitemap.ts` automatically discovers all content by reading the MDX files in `src/data/blog/`,
+`src/data/work/`, and `src/data/projects/` at build time. Adding a new `.mdx` file is all it takes, therefore no
+manual edits to the sitemap are required.
+
+If you add entirely new static pages (outside of the existing content types), add them to the `staticRoutes`
+array at the top of `src/app/sitemap.ts`. However, for most portfolio use cases, the existing dynamic routes
+should cover all your needs without modification.

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import { siteMetadata } from "@/data/metadata"
+import { getAllBlogPosts, getAllProjects, getAllWorkItems } from "@/lib/mdx"
 import type { MetadataRoute } from "next"
 
 const base = siteMetadata.siteUrl
@@ -6,8 +7,16 @@ const base = siteMetadata.siteUrl
 /**
  * Generates a sitemap.xml file for the website.
  */
-export default function sitemap(): MetadataRoute.Sitemap {
-  return [
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const [posts, workItems, projects] = await Promise.all([
+    getAllBlogPosts(),
+    getAllWorkItems(),
+    getAllProjects(),
+  ])
+
+  const tags = [...new Set(posts.flatMap(post => post.tags ?? []))]
+
+  const staticRoutes: MetadataRoute.Sitemap = [
     {
       url: base,
       lastModified: new Date(),
@@ -33,4 +42,34 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.8,
     },
   ]
+
+  const blogPostRoutes: MetadataRoute.Sitemap = posts.map(post => ({
+    url: `${base}/blog/${post.slug}`,
+    lastModified: new Date(post.date),
+    changeFrequency: "monthly",
+    priority: 0.6,
+  }))
+
+  const blogTagRoutes: MetadataRoute.Sitemap = tags.map(tag => ({
+    url: `${base}/blog/tag/${tag}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly",
+    priority: 0.5,
+  }))
+
+  const workRoutes: MetadataRoute.Sitemap = workItems.map(item => ({
+    url: `${base}/work/${item.slug}`,
+    lastModified: new Date(),
+    changeFrequency: "yearly",
+    priority: 0.6,
+  }))
+
+  const projectRoutes: MetadataRoute.Sitemap = projects.map(project => ({
+    url: `${base}/projects/${project.slug}`,
+    lastModified: new Date(project.endDate),
+    changeFrequency: "monthly",
+    priority: 0.6,
+  }))
+
+  return [...staticRoutes, ...blogPostRoutes, ...blogTagRoutes, ...workRoutes, ...projectRoutes]
 }


### PR DESCRIPTION
## Description

[//]: # "Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context."

Prior to this change, `sitemap.xml` was statically defined, and did not include `/work/[slug]`, `/projects/[slug]`, `/blog/[slug]` or `/blog/tag/[slug]` pages. With this change, now we do.

## Type of Change

[//]: # "Please select one"

- [X] Feature
- [ ] Bugfix
- [ ] Refactor
- [X] Documentation
- [ ] Other

## Checklist

[//]: # "Please check all that apply"

- [X] Manually tested by running `pnpm dev` and viewing all pages
- [X] It can build a prod build with `pnpm build`
- [X] Documentation and comments added
- [X] No console warnings or errors
- [X] No ESLint warnings or errors
- [X] No prettier warnings or errors
- [X] No vitest warnings or errors

## Supplementary Information

[//]: # "Any other information that is important to this PR, such as screenshots of a UI change"
